### PR TITLE
Fix search error when searching for records

### DIFF
--- a/src/main/java/com/example/aar/controller/AbductionController.java
+++ b/src/main/java/com/example/aar/controller/AbductionController.java
@@ -49,4 +49,9 @@ public class AbductionController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
     }
+
+    @GetMapping("/search")
+    public List<Abduction> searchAbductions(@RequestParam("query") String query) {
+        return abductionService.searchAbductions(query);
+    }
 }

--- a/src/main/java/com/example/aar/repository/AbductionRepository.java
+++ b/src/main/java/com/example/aar/repository/AbductionRepository.java
@@ -2,8 +2,15 @@ package com.example.aar.repository;
 
 import com.example.aar.model.Abduction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface AbductionRepository extends JpaRepository<Abduction, Long> {
+
+    @Query("SELECT a FROM Abduction a WHERE a.name LIKE %:query% OR a.place LIKE %:query% OR a.details LIKE %:query%")
+    List<Abduction> findByNameContainingOrPlaceContainingOrDetailsContaining(@Param("query") String query);
 }

--- a/src/main/java/com/example/aar/service/AbductionService.java
+++ b/src/main/java/com/example/aar/service/AbductionService.java
@@ -35,4 +35,8 @@ public class AbductionService {
     public Abduction getAbductionById(Long id) {
         return abductionRepository.findById(id).orElse(null);
     }
+
+    public List<Abduction> searchAbductions(String query) {
+        return abductionRepository.findByNameContainingOrPlaceContainingOrDetailsContaining(query);
+    }
 }


### PR DESCRIPTION
Add search functionality to handle non-numeric input without causing a `MethodArgumentTypeMismatchException`.

* **AbductionController.java**
  - Add `searchAbductions` method to handle search queries.
  - Annotate the method with `@GetMapping("/search")`.
  - Use `@RequestParam("query")` to get the search query from the request.
  - Call the `searchAbductions` method from `abductionService`.

* **AbductionRepository.java**
  - Add `findByNameContainingOrPlaceContainingOrDetailsContaining` method to search for abductions based on a query.
  - Annotate the method with `@Query` and use JPQL to search for abductions.
  - Use `@Param` to pass the search query to the method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jimleitch01/aar/pull/4?shareId=610d37e8-b1d0-449b-83f7-77040961d51a).