### PR TITLE
Fix error in CustomErrorController

### DIFF
--- a/src/main/java/com/example/aar/controller/CustomErrorController.java
+++ b/src/main/java/com/example/aar/controller/CustomErrorController.java
@@ -11,9 +11,4 @@ public class CustomErrorController implements ErrorController {
     public String handleError() {
         return "error/404";
     }
-
-    @Override
-    public String getErrorPath() {
-        return "/error";
-    }
 }


### PR DESCRIPTION
Remove the `getErrorPath` method from the `CustomErrorController` class.

* Remove the `@Override` annotation and the `getErrorPath` method implementation from `CustomErrorController`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jimleitch01/aar/pull/6?shareId=482a30b8-3260-4c74-9e31-c4e7ebf76f83).